### PR TITLE
patch readme update bmx libraries links as target repo has been archived

### DIFF
--- a/FFmpeg-patches/README.md
+++ b/FFmpeg-patches/README.md
@@ -21,7 +21,7 @@ git apply /path/to/FFmpeg-patches/*.patch
 
 ## BMX
 
-Firstly, build bmx libraries `libMXF`, `libMXF++` and `bmx`. The instructions are [here](https://sourceforge.net/p/bmxlib/home/Home/).
+Firstly, build bmx libraries [libMXF](https://github.com/ebu/bmx/tree/main/deps/libMXF), [libMXF++](https://github.com/ebu/bmx/tree/main/deps/libMXFpp) and [bmx](https://github.com/ebu/bmx).
 
 Build `cbmx` library :
 


### PR DESCRIPTION
Le sourceforge redirige les libs vers https://github.com/bbc/bmx/. 
Mais le repo a été archivé et un nouveau fork a été créé (par l'ebu) https://github.com/ebu/bmx/